### PR TITLE
Add support for excluding words from capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Configuration (TypeScript type).
 - `lowerCaseWords` (`string[]`, optional, example: `['die', 'der', 'und']`)
   — extends the default list of lowercase words.
 
+- `exclude` (`string[]`, optional, example: `['remark-lint', 'remark']`)
+  — exclude the words from capitalization.
+
 ## Examples
 
 When this rule is turned on, the following `valid.md` is ok:

--- a/index.js
+++ b/index.js
@@ -2,36 +2,57 @@ import { lintRule } from 'unified-lint-rule'
 import { visit } from 'unist-util-visit'
 
 import lowerCaseWords from './lib/lowerCaseWords.js'
-import { capitalizeWord, isUpperCase } from './lib/utils.js'
+import { capitalizeWord, isUpperCase, isWordExcluded } from './lib/utils.js'
 
 const cache = {}
 
 export function fixTitle(title, options) {
-  const correctTitle = title.replace(/[^\s-]+/g, (word, index) => {
-
-    // If the word is already in uppercase, return it as is.
-    if (isUpperCase(word)) {
+  // Split the title into words by spaces
+  const correctTitle = title.replace(/[^\s]+/g, (word, wordPositionInTitle) => {
+    if (isWordExcluded(word, options)) {
       return word
     }
 
-    // If the word is not the first word in the title and should be lowercase, return it in lowercase.
-    const lowerCaseWord = word.toLowerCase()
-    if (index !== 0 && [...lowerCaseWords, ...(options.lowerCaseWords ?? [])].includes(lowerCaseWord)) {
-      return lowerCaseWord
-    }
-
-    // Checking the first letter of a word is not capitalized.
-    if (!isUpperCase(word.charAt(0))) {
-      return capitalizeWord(word)
-    }
-
-    return word
+    // Split hyphenated word to words by hyphens
+    // Applies word correction base on position in the title and position in the hyphenated word
+    return word.replace(/[^-]+/g, (hyphenatedWord, hyphenatedWordPosition) =>
+      correctWord(
+        hyphenatedWord,
+        hyphenatedWordPosition + wordPositionInTitle,
+        options
+      )
+    )
   })
 
   // Putting correct title in the cache for prevent handling the same titles in other docs.
   cache[correctTitle] = correctTitle
 
   return correctTitle
+}
+
+function correctWord(word, wordPosition, options = {}) {
+  // If the word is already in uppercase, return it as is.
+  if (isUpperCase(word)) {
+    return word
+  }
+
+  // If the word is not the first word in the title and should be lowercase, return it in lowercase.
+  const lowerCaseWord = word.toLowerCase()
+  if (
+    wordPosition !== 0 &&
+    [...lowerCaseWords, ...(options.lowerCaseWords ?? [])].includes(
+      lowerCaseWord
+    )
+  ) {
+    return lowerCaseWord
+  }
+
+  // Checking the first letter of a word is not capitalized.
+  if (!isUpperCase(word.charAt(0))) {
+    return capitalizeWord(word)
+  }
+
+  return word
 }
 
 function headingCapitalization(tree, file, options = {}) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,3 +5,7 @@ export function capitalizeWord(word) {
 export function isUpperCase(word) {
   return word === word.toLocaleUpperCase()
 }
+
+export function isWordExcluded(word, options) {
+  return options?.exclude?.includes(word)
+}

--- a/test/test.js
+++ b/test/test.js
@@ -49,3 +49,13 @@ test('custom list of lowercase words', async () => {
 
   assert.strictEqual(result1.messages.length, 0)
 })
+
+test('custom list of excluded words', async () => {
+  const result1 = await remark()
+    .use(remarkLintHeadingCapitalization, {
+      exclude: ['remark-lint', 'remark']
+    })
+    .process('# Contributing to `remark-lint` and `remark`')
+
+  assert.strictEqual(result1.messages.length, 0)
+})


### PR DESCRIPTION
Hi, based on my request in https://github.com/ilyatitovich/remark-lint-heading-capitalization/issues/13 I have prepared this PR that adds an `exclude` option for removing words from capitalization.

To be able to do this I have refactored the code a little bit and created two steps of title parsing.
Firstly, the title is split into words only by space so I am able to detect and also exclude the word with hyphens.
Secondly, if the word with hyphens is not excluded, it will be split and words will be corrected the same way as before.

I hope this is fine.
I am awaiting your review.
Thanks :-)