### PR TITLE
Introduce `ignorePattern` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Configuration (TypeScript type).
 - `exclude` (`string[]`, optional, example: `['remark-lint', 'remark']`)
   — exclude the words from capitalization.
 
+- `ignorePattern` (`string` || `string[]`, optional, example: `'package-[a-z]+'` or `['package-[a-z]+', 'node-[0-9]+']`)
+  — an array of or string regular expression pattern to ignore things that match the pattern.
+
 ## Examples
 
 When this rule is turned on, the following `valid.md` is ok:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Configuration (TypeScript type).
 - `lowerCaseWords` (`string[]`, optional, example: `['die', 'der', 'und']`)
   — extends the default list of lowercase words.
 
+- `exclude` (`string[]`, optional, example: `['remark-lint', 'remark']`)
+  — exclude the words from capitalization.
+
 ## Examples
 
 When this rule is turned on, the following `valid.md` is ok:

--- a/index.js
+++ b/index.js
@@ -2,36 +2,57 @@ import { lintRule } from 'unified-lint-rule'
 import { visit } from 'unist-util-visit'
 
 import lowerCaseWords from './lib/lowerCaseWords.js'
-import { capitalizeWord, isUpperCase } from './lib/utils.js'
+import { capitalizeWord, isUpperCase, isWordExcluded } from './lib/utils.js'
 
 const cache = {}
 
 export function fixTitle(title, options) {
-  const correctTitle = title.replace(/[^\s-]+/g, (word, index) => {
-
-    // If the word is already in uppercase, return it as is.
-    if (isUpperCase(word)) {
+  // Split the title into words by spaces
+  const correctTitle = title.replace(/[^\s]+/g, (word, wordPositionInTitle) => {
+    if (isWordExcluded(word, options)) {
       return word
     }
 
-    // If the word is not the first word in the title and should be lowercase, return it in lowercase.
-    const lowerCaseWord = word.toLowerCase()
-    if (index !== 0 && [...lowerCaseWords, ...(options.lowerCaseWords ?? [])].includes(lowerCaseWord)) {
-      return lowerCaseWord
-    }
-
-    // Checking the first letter of a word is not capitalized.
-    if (!isUpperCase(word.charAt(0))) {
-      return capitalizeWord(word)
-    }
-
-    return word
+    // Split hyphenated word to words by hyphens
+    // Applies word correction base on position in the title and position in the hyphenated word
+    return word.replace(/[^-]+/g, (hyphenatedWord, hyphenatedWordPosition) =>
+      correctWord(
+        hyphenatedWord,
+        hyphenatedWordPosition + wordPositionInTitle,
+        options
+      )
+    )
   })
 
   // Putting correct title in the cache for prevent handling the same titles in other docs.
   cache[correctTitle] = correctTitle
 
   return correctTitle
+}
+
+function correctWord(word, wordPosition, options = {}) {
+  // If the word is already in uppercase, return it as is.
+  if (isUpperCase(word)) {
+    return word
+  }
+
+  // If the word is not the first word in the title and should be lowercase, return it in lowercase.
+  const lowerCaseWord = word.toLowerCase()
+  if (
+    wordPosition !== 0 &&
+    [...lowerCaseWords, ...(options.lowerCaseWords ?? [])].includes(
+      lowerCaseWord
+    )
+  ) {
+    return lowerCaseWord
+  }
+
+  // Checking the first letter of a word is not capitalized.
+  if (!isUpperCase(word.charAt(0))) {
+    return capitalizeWord(word)
+  }
+
+  return word
 }
 
 function headingCapitalization(tree, file, options = {}) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,3 +5,7 @@ export function capitalizeWord(word) {
 export function isUpperCase(word) {
   return word === word.toLocaleUpperCase()
 }
+
+export function isWordExcluded(word, options) {
+  return options?.exclude?.includes(word)
+}

--- a/package.json
+++ b/package.json
@@ -66,5 +66,6 @@
   "dependencies": {
     "unified-lint-rule": "^2.1.2",
     "unist-util-visit": "^5.0.0"
-  }
+  },
+  "packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c"
 }

--- a/test/test.js
+++ b/test/test.js
@@ -49,3 +49,13 @@ test('custom list of lowercase words', async () => {
 
   assert.strictEqual(result1.messages.length, 0)
 })
+
+test('custom list of excluded words', async () => {
+  const result1 = await remark()
+    .use(remarkLintHeadingCapitalization, {
+      exclude: ['remark-lint', 'remark']
+    })
+    .process('# Contributing to `remark-lint` and `remark`')
+
+  assert.strictEqual(result1.messages.length, 0)
+})

--- a/test/test.js
+++ b/test/test.js
@@ -59,3 +59,45 @@ test('custom list of excluded words', async () => {
 
   assert.strictEqual(result1.messages.length, 0)
 })
+
+test('custom ignored pattern', async () => {
+  const result1 = await remark()
+    .use(remarkLintHeadingCapitalization, {
+      ignorePattern: ['`[^`]+`']
+    })
+    .process('# How to Use Our `awesome` Library')
+
+  assert.strictEqual(result1.messages.length, 0)
+})
+
+test('custom ignored pattern on multiple words', async () => {
+  const result1 = await remark()
+    .use(remarkLintHeadingCapitalization, {
+      ignorePattern: ['`[^`]+`']
+    })
+    .process('# How to Use Our `awesome` Library with `magical-stuff`!')
+
+  assert.strictEqual(result1.messages.length, 0)
+})
+
+test('custom ignored pattern with a string', async () => {
+  const result1 = await remark()
+    .use(remarkLintHeadingCapitalization, {
+      ignorePattern: 'package-[a-z]+'
+    })
+    .process('# Read About Our package-manager Barn!')
+
+  assert.strictEqual(result1.messages.length, 0)
+})
+
+test('custom multiple ignored patterns', async () => {
+  const result1 = await remark()
+    .use(remarkLintHeadingCapitalization, {
+      ignorePattern: ['package-[a-z]+', '`[^`]+`']
+    })
+    .process('# Read About Our package-manager Barn! Also Check Our `awesome` Library!')
+
+  console.log(result1.messages);
+
+  assert.strictEqual(result1.messages.length, 0)
+})


### PR DESCRIPTION
This option allows users to ignore patterns that are not linted using regular expressions.

Another improvement is to keep backticks around inline code nodes.