### PR TITLE
Fix undefined error when value of node children missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,25 @@ import { capitalizeWord, isUpperCase } from './lib/utils.js'
 
 const cache = {}
 
+export function extractContent(node) {
+  // If the node is a text node, return the value
+  if (node.type === 'text') {
+    return node.value || ''
+  }
+
+  // If the node is an inlineCode node, return the value wrapped in backticks
+  if (node.type === 'inlineCode') {
+    return node.value ? `\`${node.value}\`` : ''
+  }
+
+  // If the node has children, return the concatenated value of all children
+  if (node.children && Array.isArray(node.children)) {
+    return node.children.map(extractContent).join('')
+  }
+
+  return node.value || ''
+}
+
 export function fixTitle(title, options) {
   const correctTitle = title.replace(/[^\s-]+/g, (word, index) => {
     // If the word is already in uppercase, return it as is.
@@ -50,12 +69,7 @@ function headingCapitalization(tree, file, options = {}) {
   }
 
   visit(tree, 'heading', node => {
-    let processedTitle = node.children.reduce(
-      (acc, child) =>
-        acc +
-        (child.type === 'inlineCode' ? `\`${child.value}\`` : child.value),
-      ''
-    )
+    let processedTitle = extractContent(node)
 
     // Create a processed version of the title by removing ignored patterns
     for (const regex of ignorePatterns) {

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { remark } from 'remark'
 import { compareMessage } from 'vfile-sort'
+import { extractContent } from '../index.js';
 import remarkLintHeadingCapitalization from '../index.js'
 
 const invalidMdPath = path.join(import.meta.dirname, 'docs', 'invalid.md')
@@ -90,4 +91,50 @@ test('custom multiple ignored patterns', async () => {
     )
 
   assert.strictEqual(result1.messages.length, 0)
+})
+
+test('heading with link', async () => {
+  const result1 = await remark()
+    .use(remarkLintHeadingCapitalization)
+    .process(
+      '# Check Out [Our Awesome Library](https://example.com) for More Info!'
+    )
+
+  assert.strictEqual(result1.messages.length, 0)
+})
+
+test('extracting various content from a heading node', async () => {
+  const tree = {
+    type: 'heading',
+    children: [
+      {
+        type: 'text',
+        value: 'Hello, World! '
+      },
+      {
+        type: 'lorem',
+      },
+      {
+        type: 'inlineCode',
+        value: 'code'
+      },
+      {
+        type: 'text',
+        value: ' '
+      },
+      {
+        type: 'linkReference',
+        children: [
+          {
+            type: 'text',
+            value: 'Link'
+          }
+        ]
+      }
+    ]
+  }
+
+  const content = extractContent(tree)
+
+  assert.strictEqual(content, 'Hello, World! `code` Link')
 })


### PR DESCRIPTION
Also, introduce support for nested children values.

I accidentally introduced a bug in which if the `value` was missing in the node children item, it returned `undefined`, and the plugin flagged it as not being `Undefined`. Sorry about that.

It flagged a heading in our repo with a link.

```
## Using with [Item][item] component
```

This PR introduces a new function, `extractContent`, which returns all values from all nodes if they are set.