### PR TITLE
Add option to allow lowercase first words in headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,25 @@ npm install remark-lint-heading-capitalization
 Use like any other [remark-lint](https://github.com/remarkjs/remark-lint) plugin.
 Check out the [remark-lint](https://github.com/remarkjs/remark-lint) documentation for details.
 
-### `Options`
+### Options
 
 Configuration (TypeScript type).
 
-###### Fields
-
 - `lowerCaseWords` (`string[]`, optional, example: `['die', 'der', 'und']`)
   — extends the default list of lowercase words.
+
 - `ignorePattern` (`string | string[]`, optional, example: `'package-[a-z]+'` or `['package-[a-z]+', 'node-[0-9]+']`)
   — a single regular expression pattern as a string or an array of strings, used to ignore items that match the specified pattern(s).
+
+- `allowFirstWordLowerCase` (`boolean`, default: `false`)
+
+  - `true`: Allows the first word of a heading to be lowercase, but **only** if that word is explicitly listed in your custom `lowerCaseWords` array.
+
+    Words from the default lowercase list (such as "a", "the", "and", etc.) will **not** be allowed as a lowercase first word unless you add them to your custom list.
+
+  - `false`: The first word is always capitalized unless it is already all uppercase.
+
+  With this configuration, a heading like `die besten Tricks` or `the quick brown fox` will not be flagged, but `an apple` will still be flagged unless `"an"` is added to `lowerCaseWords`.
 
 ## Examples
 

--- a/index.js
+++ b/index.js
@@ -13,13 +13,23 @@ export function fixTitle(title, options) {
       return word
     }
 
-    // If the word is not the first word in the title and should be lowercase, return it in lowercase.
+    // If true, words in options.lowerCaseWords can also apply to the first word in the title.
+    // Words in the default list will instead be capitalized by default if they are the first word, UNLESS they're explicitly included in the user's custom list
+    const allowFirstWordLowerCase = options.allowFirstWordLowerCase ?? false
+
+    // Words that should always be lowercase, (applies only to non-first words, unless allowFirstWordLowerCase is true)
+    const userLowerCaseWords = options.lowerCaseWords ?? []
+
     const lowerCaseWord = word.toLowerCase()
+    const allLowerCaseWords = [...lowerCaseWords, ...userLowerCaseWords]
+
+    // Only allow first word to be lowercase if it's in the user's custom list and allowFirstWordLowerCase is true.
     if (
-      index !== 0 &&
-      [...lowerCaseWords, ...(options.lowerCaseWords ?? [])].includes(
-        lowerCaseWord
-      )
+      allLowerCaseWords.includes(lowerCaseWord) &&
+      ((index === 0 &&
+        allowFirstWordLowerCase &&
+        userLowerCaseWords.includes(lowerCaseWord)) ||
+        index !== 0)
     ) {
       return lowerCaseWord
     }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import { lintRule } from 'unified-lint-rule'
 import { visit } from 'unist-util-visit'
 
-import lowerCaseWords from './lib/lowerCaseWords.js'
+import defaultLowerCaseWords from './lib/defaultLowerCaseWords.js'
 import { capitalizeWord, isUpperCase } from './lib/utils.js'
 
 const cache = {}
@@ -20,8 +20,9 @@ export function fixTitle(title, options) {
     // Words that should always be lowercase, (applies only to non-first words, unless allowFirstWordLowerCase is true)
     const userLowerCaseWords = options.lowerCaseWords ?? []
 
+    const allLowerCaseWords = [...defaultLowerCaseWords, ...userLowerCaseWords]
+
     const lowerCaseWord = word.toLowerCase()
-    const allLowerCaseWords = [...lowerCaseWords, ...userLowerCaseWords]
 
     // Only allow first word to be lowercase if it's in the user's custom list and allowFirstWordLowerCase is true.
     if (
@@ -42,7 +43,7 @@ export function fixTitle(title, options) {
     return word
   })
 
-  // Putting correct title in the cache for prevent handling the same titles in other docs.
+  // Putting correct title in the cache to prevent handling the same titles in other docs.
   cache[correctTitle] = correctTitle
 
   return correctTitle
@@ -94,3 +95,4 @@ const remarkLintHeadingCapitalization = lintRule(
 )
 
 export default remarkLintHeadingCapitalization
+export { cache }

--- a/lib/defaultLowerCaseWords.js
+++ b/lib/defaultLowerCaseWords.js
@@ -1,4 +1,4 @@
-export default [
+const defaultLowerCaseWords = [
   'a',
   'an',
   'the',
@@ -16,5 +16,7 @@ export default [
   'in',
   'of',
   'on',
-  'with',
+  'with'
 ]
+
+export default defaultLowerCaseWords

--- a/test/test.js
+++ b/test/test.js
@@ -91,3 +91,65 @@ test('custom multiple ignored patterns', async () => {
 
   assert.strictEqual(result1.messages.length, 0)
 })
+
+test('[allowFirstWordLowerCase] allow custom lowercase first word', async () => {
+  const result = await remark()
+    .use(remarkLintHeadingCapitalization, {
+      allowFirstWordLowerCase: true,
+      lowerCaseWords: ['cats', 'dogs', 'both']
+    })
+    .process('# cats or dogs or both')
+
+  assert.strictEqual(result.messages.length, 0)
+})
+
+test('[allowFirstWordLowerCase] allow custom lowercase first word when formatted', async () => {
+  const result = await remark()
+    .use(remarkLintHeadingCapitalization, {
+      allowFirstWordLowerCase: true,
+      lowerCaseWords: ['cats', 'are', 'great']
+    })
+    .process(
+      `# \`cats\` are great
+    ## _cats_ are great
+    ## __cats__ are great
+    ## *cats* are great
+    ## **cats** are great
+    ## ~~cats~~ are great`
+    )
+
+  assert.strictEqual(result.messages.length, 0)
+})
+
+test('[allowFirstWordLowerCase] capitalize first word when flag is true but no custom words specified', async () => {
+  const result = await remark()
+    .use(remarkLintHeadingCapitalization, {
+      allowFirstWordLowerCase: true,
+      lowerCaseWords: [] // No custom lowerCaseWords provided because we want to test default behavior
+    })
+    .process('# the quick brown fox')
+
+  assert.strictEqual(result.messages.length, 1)
+})
+
+test('[allowFirstWordLowerCase] do not capitalize default lower case word explicitly specified', async () => {
+  const result = await remark()
+    .use(remarkLintHeadingCapitalization, {
+      allowFirstWordLowerCase: true,
+      lowerCaseWords: ['the', 'fox'] // `The` is in the default list, but we want to test that it is not capitalized when explicitly included in the user's custom list
+    })
+    .process('# the Quick Brown fox')
+
+  assert.strictEqual(result.messages.length, 0)
+})
+
+test('[allowFirstWordLowerCase] option disabled, capitalize first word even if in list', async () => {
+  const result = await remark()
+    .use(remarkLintHeadingCapitalization, {
+      allowFirstWordLowerCase: false,
+      lowerCaseWords: ['the'] // No custom lowerCaseWords provided because we want to test default behavior
+    })
+    .process('# the quick brown fox')
+
+  assert.strictEqual(result.messages.length, 1)
+})

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,7 @@ const validMdPath = path.join(import.meta.dirname, 'docs', 'valid.md')
 const invalidMd = fs.readFileSync(invalidMdPath, 'utf-8')
 const validMd = fs.readFileSync(validMdPath, 'utf-8')
 
-test('find wrong capitalizations in headings', async () => {
+test('[no options] find wrong capitalizations in headings', async () => {
   const result = await remark()
     .use(remarkLintHeadingCapitalization)
     .process(invalidMd)
@@ -32,7 +32,7 @@ test('find wrong capitalizations in headings', async () => {
   )
 })
 
-test('no errors found', async () => {
+test('[no options] no errors found', async () => {
   const result = await remark()
     .use(remarkLintHeadingCapitalization)
     .process(validMd)
@@ -40,7 +40,7 @@ test('no errors found', async () => {
   assert.strictEqual(result.messages.length, 0)
 })
 
-test('custom list of lowercase words', async () => {
+test('[lowerCaseWords] custom list of lowercase words', async () => {
   const result1 = await remark()
     .use(remarkLintHeadingCapitalization, {
       lowerCaseWords: ['die', 'der', 'und']
@@ -50,7 +50,7 @@ test('custom list of lowercase words', async () => {
   assert.strictEqual(result1.messages.length, 0)
 })
 
-test('custom ignored pattern', async () => {
+test('[ignorePattern] custom ignored pattern', async () => {
   const result1 = await remark()
     .use(remarkLintHeadingCapitalization, {
       ignorePattern: ['`[^`]+`']
@@ -60,7 +60,7 @@ test('custom ignored pattern', async () => {
   assert.strictEqual(result1.messages.length, 0)
 })
 
-test('custom ignored pattern on multiple words', async () => {
+test('[ignorePattern] custom ignored pattern on multiple words', async () => {
   const result1 = await remark()
     .use(remarkLintHeadingCapitalization, {
       ignorePattern: ['`[^`]+`']
@@ -70,7 +70,7 @@ test('custom ignored pattern on multiple words', async () => {
   assert.strictEqual(result1.messages.length, 0)
 })
 
-test('custom ignored pattern with a string', async () => {
+test('[ignorePattern] custom ignored pattern with a string', async () => {
   const result1 = await remark()
     .use(remarkLintHeadingCapitalization, {
       ignorePattern: 'package-[a-z]+'
@@ -80,7 +80,7 @@ test('custom ignored pattern with a string', async () => {
   assert.strictEqual(result1.messages.length, 0)
 })
 
-test('custom multiple ignored patterns', async () => {
+test('[ignorePattern] custom multiple ignored patterns', async () => {
   const result1 = await remark()
     .use(remarkLintHeadingCapitalization, {
       ignorePattern: ['package-[a-z]+', '`[^`]+`']

--- a/test/test.js
+++ b/test/test.js
@@ -149,7 +149,7 @@ test('[allowFirstWordLowerCase] option disabled, capitalize first word even if i
       allowFirstWordLowerCase: false,
       lowerCaseWords: ['the'] // No custom lowerCaseWords provided because we want to test default behavior
     })
-    .process('# the quick brown fox')
+    .process('# the Quick Brown Fox')
 
   assert.strictEqual(result.messages.length, 1)
 })

--- a/test/test.js
+++ b/test/test.js
@@ -5,12 +5,20 @@ import test from 'node:test'
 import { remark } from 'remark'
 import { compareMessage } from 'vfile-sort'
 import remarkLintHeadingCapitalization from '../index.js'
+import { cache } from '../index.js'
 
 const invalidMdPath = path.join(import.meta.dirname, 'docs', 'invalid.md')
 const validMdPath = path.join(import.meta.dirname, 'docs', 'valid.md')
 
 const invalidMd = fs.readFileSync(invalidMdPath, 'utf-8')
 const validMd = fs.readFileSync(validMdPath, 'utf-8')
+
+test.beforeEach(() => {
+  // Clear the cache before each test to ensure a clean state
+  for (const key in cache) {
+    delete cache[key]
+  }
+})
 
 test('[no options] find wrong capitalizations in headings', async () => {
   const result = await remark()
@@ -127,18 +135,21 @@ test('[allowFirstWordLowerCase] capitalize first word when flag is true but no c
       allowFirstWordLowerCase: true,
       lowerCaseWords: [] // No custom lowerCaseWords provided because we want to test default behavior
     })
-    .process('# the quick brown fox')
+    .process('# a Quick Brown Fox')
 
-  assert.strictEqual(result.messages.length, 1)
+  assert.match(
+    result.messages[0].reason,
+    /Heading capitalization error. Expected: 'A Quick Brown Fox' found: 'a Quick Brown Fox'/
+  )
 })
 
 test('[allowFirstWordLowerCase] do not capitalize default lower case word explicitly specified', async () => {
   const result = await remark()
     .use(remarkLintHeadingCapitalization, {
       allowFirstWordLowerCase: true,
-      lowerCaseWords: ['the', 'fox'] // `The` is in the default list, but we want to test that it is not capitalized when explicitly included in the user's custom list
+      lowerCaseWords: ['the'] // `The` is in the default list, but we want to test that it is not capitalized when explicitly included in the user's custom list and it appears as the first word
     })
-    .process('# the Quick Brown fox')
+    .process('# the Quick Brown Fox')
 
   assert.strictEqual(result.messages.length, 0)
 })
@@ -147,9 +158,82 @@ test('[allowFirstWordLowerCase] option disabled, capitalize first word even if i
   const result = await remark()
     .use(remarkLintHeadingCapitalization, {
       allowFirstWordLowerCase: false,
-      lowerCaseWords: ['the'] // No custom lowerCaseWords provided because we want to test default behavior
+      lowerCaseWords: ['blah']
     })
-    .process('# the Quick Brown Fox')
-
+    .process('# blah Quick Brown Fox')
   assert.strictEqual(result.messages.length, 1)
+})
+
+test('[cache] Add title to cache', async () => {
+  const result = await remark()
+    .use(remarkLintHeadingCapitalization, {
+      allowFirstWordLowerCase: true,
+      lowerCaseWords: ['foo']
+    })
+    .process('# foo Bar Baz')
+
+  console.log(result)
+  assert.strictEqual(result.messages.length, 0)
+})
+
+test('[cache] change option flag and make sure cache does not persist', async () => {
+  const result = await remark()
+    .use(remarkLintHeadingCapitalization, {
+      allowFirstWordLowerCase: false,
+      // flag is now false while the rest remains the same, so we expect an error.
+      // Cache must be invalidated for this to pass
+
+      // NOTE: I'm not sure if it may also be necessary to invalidate cache in a non-test scenario.
+      // For now, this is just a test to ensure that the cache is not persisting across different runs with different options.
+      lowerCaseWords: ['foo']
+    })
+    .process('# foo Bar Baz')
+
+  assert.match(
+    result.messages[0].reason,
+    /Heading capitalization error. Expected: 'Foo Bar Baz' found: 'foo Bar Baz'/
+  )
+})
+
+test('[cache] cache persistance', async () => {
+  // We clear cache after each test, so to properly test it we must process the same title multiple times in the same test.
+
+  const duplicatedTitle = 'Foo bar Baz'
+  const otherTitle = 'Another Random Title'
+
+  const same1 = `# ${duplicatedTitle}`
+  const same2 = `## ${duplicatedTitle}`
+
+  const other = `# ${otherTitle}`
+
+  // Process document with repeated headings
+  await remark().use(remarkLintHeadingCapitalization, {
+    lowerCaseWords: ['bar']
+  }).process(`${same1}
+${same1}
+${other}
+${same1}
+`)
+
+  // Should contain both 'Foo bar Baz' and 'Another Random Title'
+  const keys = Object.keys(cache)
+  assert(keys.includes(duplicatedTitle))
+  assert(keys.includes(otherTitle))
+  assert.strictEqual(keys.length, 2)
+
+  console.log('1: ', cache)
+
+  // Process again with different heading levels
+  await remark().use(remarkLintHeadingCapitalization, {
+    lowerCaseWords: ['bar']
+  }).process(`${same2}
+${same2}
+${other}
+${same2}
+`)
+
+  const keys2 = Object.keys(cache)
+  assert(keys2.includes(duplicatedTitle))
+  assert(keys2.includes(otherTitle))
+  assert.strictEqual(keys2.length, 2)
 })

--- a/test/test.js
+++ b/test/test.js
@@ -172,7 +172,6 @@ test('[cache] Add title to cache', async () => {
     })
     .process('# foo Bar Baz')
 
-  console.log(result)
   assert.strictEqual(result.messages.length, 0)
 })
 
@@ -220,8 +219,6 @@ ${same1}
   assert(keys.includes(duplicatedTitle))
   assert(keys.includes(otherTitle))
   assert.strictEqual(keys.length, 2)
-
-  console.log('1: ', cache)
 
   // Process again with different heading levels
   await remark().use(remarkLintHeadingCapitalization, {

--- a/test/test.js
+++ b/test/test.js
@@ -158,9 +158,9 @@ test('[allowFirstWordLowerCase] option disabled, capitalize first word even if i
   const result = await remark()
     .use(remarkLintHeadingCapitalization, {
       allowFirstWordLowerCase: false,
-      lowerCaseWords: ['blah']
+      lowerCaseWords: ['the']
     })
-    .process('# blah Quick Brown Fox')
+    .process('# the Quick Brown Fox')
   assert.strictEqual(result.messages.length, 1)
 })
 


### PR DESCRIPTION
This adds the `allowFirstWordLowerCase` boolean option, which behaves as follows:
 - `true`: Allows the first word of a heading to be lowercase, but **only** if that word is explicitly listed in your custom `lowerCaseWords` array.
  - `false`: The first word is always capitalized unless it is already all uppercase (same as previous behavior)

Resolves #19 